### PR TITLE
Add missing header

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ class Client {
       this.base = {
         headers: {
           'Accept': 'application/json',
-          'Authorization': `Basic ${Buffer.from(`X:${apiKey}`).toString('base64')}`
+          'Authorization': `Basic ${Buffer.from(`X:${apiKey}`).toString('base64')}`,
+          'Content-Type': 'application/x-www-form-urlencoded'
         }
       }
   }


### PR DESCRIPTION
The content type header is missing and necessary for Facebook certs. We need to add tests around this but this PR does not include them.