### PR TITLE
Sc 34085/add field mapping for scan delimiter to trustedform

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ const params = {
   forbidden_text: 'scan![]',
   reference: 'reference',
   vendor: 'vendor',
+  scan_delimiter: 'scan_delimiter',
   email: 'email',
   phone_1: 'phone_1',
   phone_2: 'phone_2',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trustedform-api-client",
-  "version": "1.0.7",
+  "version": "1.0.6",
   "description": "A Node.js module for calling the TrustedForm API.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trustedform-api-client",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A Node.js module for calling the TrustedForm API.",
   "main": "index.js",
   "scripts": {

--- a/test/claim_spec.js
+++ b/test/claim_spec.js
@@ -91,13 +91,14 @@ describe('Claim', () => {
 
   it('should add expected parameters to request', () => {
     nock('https://cert.trustedform.com')
-      .post('/1234abc', 'scan%5B%5D=test')
+      .post('/1234abc', 'scan%5B%5D=test&scan_delimiter=%7C')
       .reply(201, apiResponse);
 
     const client = new Client('asdf');
     const options = {
       cert_url: 'https://cert.trustedform.com/1234abc',
-      required_text: 'test'
+      required_text: 'test',
+      scan_delimiter: '|'
     };
     client.claim(options, (err, res, body) => {
       assert.isNull(err);


### PR DESCRIPTION
## Description of the change

add support for `scan_delimiter`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/34085/add-field-mapping-for-scan-delimiter-to-trustedform-integrations

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Clubhouse has a link to this pull request.
- [ ]  This PR has a link to the issue in Clubhouse.

### QA
- [ ]  This branch has been deployed to staging and tested.
