### PR TITLE
change scan parameter names  for v3 'claims'

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ class Client {
       options.forbidden_text = [options.forbidden_text];
     }
 
+    const params = this._getParams(_.get(options.headers, 'api-version'));
     for (const param in params) {
       if (options[param]) {
         options.body[params[param]] = options[param];
@@ -71,9 +72,16 @@ class Client {
       callback(null, res, body);
     });
   }
+
+  _getParams (versionHeader) {
+    if (versionHeader !== '3.0') return paramsV2;
+
+    // TF V3 APi has different params for scan text
+    return Object.assign(paramsV2, { required_text: 'required_scan_terms[]', forbidden_text: 'forbidden_scan_terms[]' });
+  }
 }
 
-const params = {
+const paramsV2 = {
   required_text: 'scan[]',
   forbidden_text: 'scan![]',
   reference: 'reference',


### PR DESCRIPTION
## Description of the change

change scan parameter names  for v3 'claims' (consent, consent + data)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/35790/update-trustedform-consent-consent-data-page-scan-request-parameters

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
